### PR TITLE
Update `openEditor` signature as it will return null on cancellation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -52,7 +52,7 @@ declare class VESDK {
     configuration?: Configuration,
     serialization?: object,
     videoSize?: Size
-  ): Promise<VideoEditorResult>
+  ): Promise<VideoEditorResult | null>
 
   /**
    * Unlock VideoEditor SDK with a license.


### PR DESCRIPTION
TypeScript signature was incorrect on `openEditor` as it will return `null` if the user cancels.